### PR TITLE
Remove additional newlines at the end of patch files

### DIFF
--- a/parsepatch/patch.py
+++ b/parsepatch/patch.py
@@ -176,6 +176,12 @@ class Patch(object):
             if line is None:
                 break
 
+    def skip_newlines(self):
+        self._condition(lambda x: re.search('^[\n]*$', x) or re.search('^[\r]*$', x))
+        for line in self.get_lines:
+            if line is None:
+                break
+
     def is_binary(self):
         return self.line() == 'GIT binary patch'
 


### PR DESCRIPTION
Some patches will contain an empty newline. It can be safely removed.